### PR TITLE
v0.1.1

### DIFF
--- a/.github/workflows/close-pr.yml
+++ b/.github/workflows/close-pr.yml
@@ -1,0 +1,14 @@
+name: Close Pull Request
+
+on:
+  pull_request_target:
+    types: [opened]
+
+jobs:
+  close-pr:
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.user.id != github.event.repository.owner.id
+    steps:
+    - uses: superbrothers/close-pull-request@v3
+      with:
+        comment: "This repository is not accepting pull requests."

--- a/src/Frontend/Components/Gizmos/NormalGizmo.luau
+++ b/src/Frontend/Components/Gizmos/NormalGizmo.luau
@@ -3,6 +3,7 @@ local React = require("@pkgs/React")
 local e = React.createElement
 
 local LINE_THICKNESS = 0.15
+local LINE_ZINDEX = 2
 
 local function LeftRightWirebox(props: {
 	normal: Enum.NormalId,
@@ -13,16 +14,32 @@ local function LeftRightWirebox(props: {
 		return
 	end
 
-	local size = props.part.Size
+	local part = props.part
+	local size = part.Size
 
 	local x = size.X / 2
 	local y = size.Y / 2
 	local z = size.Z / 2
 
+	local side = props.normal == Enum.NormalId.Right and 1 or -1
+
+	if part:IsA("Part") then
+		if part.Shape == Enum.PartType.Ball or part.Shape == Enum.PartType.Cylinder then
+			return e("CylinderHandleAdornment", {
+				Color3 = props.color,
+				Adornee = part,
+				CFrame = CFrame.new(side * x, 0, 0)
+					* CFrame.Angles(0, side * math.pi * 0.5, 0),
+				Height = LINE_THICKNESS,
+				InnerRadius = size.Z / 2,
+				Radius = (size.Z / 2) + LINE_THICKNESS,
+				ZIndex = LINE_ZINDEX,
+			})
+		end
+	end
+
 	local sizeY = Vector3.new(LINE_THICKNESS, size.Y + LINE_THICKNESS, LINE_THICKNESS)
 	local sizeZ = Vector3.new(LINE_THICKNESS, LINE_THICKNESS, size.Z + LINE_THICKNESS)
-
-	local side = props.normal == Enum.NormalId.Right and 1 or -1
 
 	local topSize = sizeZ
 	local topCframe = CFrame.new(side * x, y, 0)
@@ -36,7 +53,15 @@ local function LeftRightWirebox(props: {
 	local rightCframe = CFrame.new(side * x, 0, -side * z)
 	local rightVisible = true
 
-	if props.part:IsA("WedgePart") then
+	local isWedge = part:IsA("WedgePart")
+	local isCornerWedge = part:IsA("CornerWedgePart")
+
+	if part:IsA("Part") then
+		isWedge = part.Shape == Enum.PartType.Wedge
+		isCornerWedge = part.Shape == Enum.PartType.CornerWedge
+	end
+
+	if isWedge then
 		local hypotenuse = math.sqrt(size.Y ^ 2 + size.Z ^ 2)
 
 		topSize =
@@ -46,7 +71,7 @@ local function LeftRightWirebox(props: {
 
 		leftVisible = side == 1
 		rightVisible = side == -1
-	elseif props.part:IsA("CornerWedgePart") then
+	elseif isCornerWedge then
 		topVisible = false
 
 		if side == -1 then
@@ -90,35 +115,35 @@ local function LeftRightWirebox(props: {
 
 	return e("Folder", nil, {
 		top = topVisible and e("BoxHandleAdornment", {
-			Adornee = props.part,
+			Adornee = part,
 			Color3 = props.color,
 			CFrame = topCframe,
 			Size = topSize,
-			ZIndex = 2,
+			ZIndex = LINE_ZINDEX,
 		}),
 
 		bottom = e("BoxHandleAdornment", {
-			Adornee = props.part,
+			Adornee = part,
 			Color3 = props.color,
 			CFrame = CFrame.new(side * x, -y, 0),
 			Size = sizeZ,
-			ZIndex = 2,
+			ZIndex = LINE_ZINDEX,
 		}),
 
 		left = leftVisible and e("BoxHandleAdornment", {
-			Adornee = props.part,
+			Adornee = part,
 			Color3 = props.color,
 			CFrame = leftCframe,
 			Size = leftSize,
-			ZIndex = 2,
+			ZIndex = LINE_ZINDEX,
 		}),
 
 		right = rightVisible and e("BoxHandleAdornment", {
-			Adornee = props.part,
+			Adornee = part,
 			Color3 = props.color,
 			CFrame = rightCframe,
 			Size = rightSize,
-			ZIndex = 2,
+			ZIndex = LINE_ZINDEX,
 		}),
 	})
 end
@@ -132,16 +157,31 @@ local function FrontBackWirebox(props: {
 		return
 	end
 
-	local size = props.part.Size
+	local part = props.part
+	local size = part.Size
 
 	local x = size.X / 2
 	local y = size.Y / 2
 	local z = size.Z / 2
 
+	local side = props.normal == Enum.NormalId.Back and 1 or -1
+
+	if part:IsA("Part") then
+		if part.Shape == Enum.PartType.Ball then
+			return e("CylinderHandleAdornment", {
+				Color3 = props.color,
+				Adornee = part,
+				CFrame = CFrame.new(0, 0, side * z),
+				Height = LINE_THICKNESS,
+				InnerRadius = size.Y / 2,
+				Radius = (size.Y / 2) + LINE_THICKNESS,
+				ZIndex = LINE_ZINDEX,
+			})
+		end
+	end
+
 	local sizeX = Vector3.new(size.X + LINE_THICKNESS, LINE_THICKNESS, LINE_THICKNESS)
 	local sizeY = Vector3.new(LINE_THICKNESS, size.Y + LINE_THICKNESS, LINE_THICKNESS)
-
-	local side = props.normal == Enum.NormalId.Back and 1 or -1
 
 	local topVisible = true
 
@@ -151,7 +191,13 @@ local function FrontBackWirebox(props: {
 	local rightSize = sizeY
 	local rightCframe = CFrame.new(side * x, 0, side * z)
 
-	if props.part:IsA("CornerWedgePart") then
+	local isCornerWedge = part:IsA("CornerWedgePart")
+
+	if part:IsA("Part") then
+		isCornerWedge = part.Shape == Enum.PartType.CornerWedge
+	end
+
+	if isCornerWedge then
 		topVisible = false
 
 		if side == 1 then
@@ -195,35 +241,35 @@ local function FrontBackWirebox(props: {
 
 	return e("Folder", nil, {
 		top = topVisible and e("BoxHandleAdornment", {
-			Adornee = props.part,
+			Adornee = part,
 			Color3 = props.color,
 			CFrame = CFrame.new(0, y, side * z),
 			Size = sizeX,
-			ZIndex = 2,
+			ZIndex = LINE_ZINDEX,
 		}),
 
 		bottom = e("BoxHandleAdornment", {
-			Adornee = props.part,
+			Adornee = part,
 			Color3 = props.color,
 			CFrame = CFrame.new(0, -y, side * z),
 			Size = sizeX,
-			ZIndex = 2,
+			ZIndex = LINE_ZINDEX,
 		}),
 
 		left = e("BoxHandleAdornment", {
-			Adornee = props.part,
+			Adornee = part,
 			Color3 = props.color,
 			CFrame = leftCframe,
 			Size = leftSize,
-			ZIndex = 2,
+			ZIndex = LINE_ZINDEX,
 		}),
 
 		right = e("BoxHandleAdornment", {
-			Adornee = props.part,
+			Adornee = part,
 			Color3 = props.color,
 			CFrame = rightCframe,
 			Size = rightSize,
-			ZIndex = 2,
+			ZIndex = LINE_ZINDEX,
 		}),
 	})
 end
@@ -237,20 +283,43 @@ local function TopBottomWirebox(props: {
 		return
 	end
 
-	if props.part:IsA("CornerWedgePart") and props.normal == Enum.NormalId.Top then
+	local part = props.part
+
+	if
+		props.normal == Enum.NormalId.Top
+		and (
+			part:IsA("CornerWedgePart")
+			or (part:IsA("Part") and part.Shape == Enum.PartType.CornerWedge)
+		)
+	then
 		return
 	end
 
-	local size = props.part.Size
+	local size = part.Size
 
 	local x = size.X / 2
 	local y = size.Y / 2
 	local z = size.Z / 2
 
+	local side = props.normal == Enum.NormalId.Bottom and -1 or 1
+
+	if part:IsA("Part") then
+		if part.Shape == Enum.PartType.Ball then
+			return e("CylinderHandleAdornment", {
+				Color3 = props.color,
+				Adornee = part,
+				CFrame = CFrame.new(0, side * y, 0)
+					* CFrame.Angles(side * math.pi * 0.5, 0, 0),
+				Height = LINE_THICKNESS,
+				InnerRadius = size.Z / 2,
+				Radius = (size.Z / 2) + LINE_THICKNESS,
+				ZIndex = LINE_ZINDEX,
+			})
+		end
+	end
+
 	local sizeX = Vector3.new(size.X + LINE_THICKNESS, LINE_THICKNESS, LINE_THICKNESS)
 	local sizeZ = Vector3.new(LINE_THICKNESS, LINE_THICKNESS, size.Z + LINE_THICKNESS)
-
-	local side = props.normal == Enum.NormalId.Bottom and -1 or 1
 
 	local backSize = sizeX
 	local backCframe = CFrame.new(0, side * y, -z)
@@ -261,52 +330,68 @@ local function TopBottomWirebox(props: {
 	local rightSize = sizeZ
 	local rightCframe = CFrame.new(x, side * y, 0)
 
-	if props.part:IsA("WedgePart") and side == 1 then
-		local hypotenuse = math.sqrt(size.Y ^ 2 + size.Z ^ 2)
-		local angle = math.atan2(size.Y, size.Z)
+	local isWedge = part:IsA("WedgePart")
 
-		backCframe = CFrame.new(0, -y, -z)
+	if part:IsA("Part") then
+		isWedge = part.Shape == Enum.PartType.Wedge
+	end
 
-		leftSize =
-			Vector3.new(LINE_THICKNESS, LINE_THICKNESS, hypotenuse + LINE_THICKNESS)
-		leftCframe = CFrame.new(-x, 0, 0) * CFrame.Angles(-angle, 0, 0)
+	if isWedge and side == 1 then
+		local topPoint = CFrame.new(0, y, z).Position
+		local bottomPoint = CFrame.new(0, -y, -z).Position
 
-		rightSize =
-			Vector3.new(LINE_THICKNESS, LINE_THICKNESS, hypotenuse + LINE_THICKNESS)
-		rightCframe = CFrame.new(x, 0, 0) * CFrame.Angles(-angle, 0, 0)
+		local topBottomMidpoint = (topPoint + bottomPoint) / 2
+
+		backCframe = CFrame.new(bottomPoint)
+
+		leftSize = Vector3.new(
+			LINE_THICKNESS,
+			LINE_THICKNESS,
+			(topPoint - bottomPoint).Magnitude + LINE_THICKNESS
+		)
+
+		leftCframe = CFrame.new(x, 0, 0) * CFrame.lookAt(topBottomMidpoint, topPoint)
+
+		rightSize = Vector3.new(
+			LINE_THICKNESS,
+			LINE_THICKNESS,
+			(topPoint - bottomPoint).Magnitude + LINE_THICKNESS
+		)
+
+		rightCframe = CFrame.new(-x, 0, 0) * CFrame.lookAt(topBottomMidpoint, topPoint)
 	end
 
 	return e("Folder", nil, {
 		left = e("BoxHandleAdornment", {
-			Adornee = props.part,
+			Adornee = part,
 			Color3 = props.color,
 			CFrame = leftCframe,
 			Size = leftSize,
-			ZIndex = 2,
+			ZIndex = LINE_ZINDEX,
 		}),
 
 		right = e("BoxHandleAdornment", {
-			Adornee = props.part,
+			Adornee = part,
 			Color3 = props.color,
 			CFrame = rightCframe,
 			Size = rightSize,
-			ZIndex = 2,
+			ZIndex = LINE_ZINDEX,
 		}),
 
 		front = e("BoxHandleAdornment", {
-			Adornee = props.part,
+			Adornee = part,
 			Color3 = props.color,
 			CFrame = CFrame.new(0, side * y, z),
 			Size = sizeX,
-			ZIndex = 2,
+			ZIndex = LINE_ZINDEX,
 		}),
 
 		back = e("BoxHandleAdornment", {
-			Adornee = props.part,
+			Adornee = part,
 			Color3 = props.color,
 			CFrame = backCframe,
 			Size = backSize,
-			ZIndex = 2,
+			ZIndex = LINE_ZINDEX,
 		}),
 	})
 end

--- a/src/Frontend/Components/Gizmos/NormalGizmo.luau
+++ b/src/Frontend/Components/Gizmos/NormalGizmo.luau
@@ -158,6 +158,15 @@ local function FrontBackWirebox(props: {
 	end
 
 	local part = props.part
+
+	local isWedge = part:IsA("WedgePart")
+	local isCornerWedge = part:IsA("CornerWedgePart")
+
+	if part:IsA("Part") then
+		isWedge = part.Shape == Enum.PartType.Wedge
+		isCornerWedge = part.Shape == Enum.PartType.CornerWedge
+	end
+
 	local size = part.Size
 
 	local x = size.X / 2
@@ -191,13 +200,33 @@ local function FrontBackWirebox(props: {
 	local rightSize = sizeY
 	local rightCframe = CFrame.new(side * x, 0, side * z)
 
-	local isCornerWedge = part:IsA("CornerWedgePart")
+	local topSize = sizeX
+	local topCframe = CFrame.new(0, y, side * z)
 
-	if part:IsA("Part") then
-		isCornerWedge = part.Shape == Enum.PartType.CornerWedge
-	end
+	if isWedge and side == -1 then
+		local topPoint = CFrame.new(0, y, z).Position
+		local bottomPoint = CFrame.new(0, -y, -z).Position
 
-	if isCornerWedge then
+		local topBottomMidpoint = (topPoint + bottomPoint) / 2
+
+		topCframe = CFrame.new(topPoint)
+
+		leftSize = Vector3.new(
+			LINE_THICKNESS,
+			LINE_THICKNESS,
+			(topPoint - bottomPoint).Magnitude + LINE_THICKNESS
+		)
+
+		leftCframe = CFrame.new(x, 0, 0) * CFrame.lookAt(topBottomMidpoint, topPoint)
+
+		rightSize = Vector3.new(
+			LINE_THICKNESS,
+			LINE_THICKNESS,
+			(topPoint - bottomPoint).Magnitude + LINE_THICKNESS
+		)
+
+		rightCframe = CFrame.new(-x, 0, 0) * CFrame.lookAt(topBottomMidpoint, topPoint)
+	elseif isCornerWedge then
 		topVisible = false
 
 		if side == 1 then
@@ -243,8 +272,8 @@ local function FrontBackWirebox(props: {
 		top = topVisible and e("BoxHandleAdornment", {
 			Adornee = part,
 			Color3 = props.color,
-			CFrame = CFrame.new(0, y, side * z),
-			Size = sizeX,
+			CFrame = topCframe,
+			Size = topSize,
 			ZIndex = LINE_ZINDEX,
 		}),
 
@@ -285,13 +314,15 @@ local function TopBottomWirebox(props: {
 
 	local part = props.part
 
-	if
-		props.normal == Enum.NormalId.Top
-		and (
-			part:IsA("CornerWedgePart")
-			or (part:IsA("Part") and part.Shape == Enum.PartType.CornerWedge)
-		)
-	then
+	local isWedge = part:IsA("WedgePart")
+	local isCornerWedge = part:IsA("CornerWedgePart")
+
+	if part:IsA("Part") then
+		isWedge = part.Shape == Enum.PartType.Wedge
+		isCornerWedge = part.Shape == Enum.PartType.CornerWedge
+	end
+
+	if props.normal == Enum.NormalId.Top and (isWedge or isCornerWedge) then
 		return
 	end
 
@@ -321,60 +352,20 @@ local function TopBottomWirebox(props: {
 	local sizeX = Vector3.new(size.X + LINE_THICKNESS, LINE_THICKNESS, LINE_THICKNESS)
 	local sizeZ = Vector3.new(LINE_THICKNESS, LINE_THICKNESS, size.Z + LINE_THICKNESS)
 
-	local backSize = sizeX
-	local backCframe = CFrame.new(0, side * y, -z)
-
-	local leftSize = sizeZ
-	local leftCframe = CFrame.new(-x, side * y, 0)
-
-	local rightSize = sizeZ
-	local rightCframe = CFrame.new(x, side * y, 0)
-
-	local isWedge = part:IsA("WedgePart")
-
-	if part:IsA("Part") then
-		isWedge = part.Shape == Enum.PartType.Wedge
-	end
-
-	if isWedge and side == 1 then
-		local topPoint = CFrame.new(0, y, z).Position
-		local bottomPoint = CFrame.new(0, -y, -z).Position
-
-		local topBottomMidpoint = (topPoint + bottomPoint) / 2
-
-		backCframe = CFrame.new(bottomPoint)
-
-		leftSize = Vector3.new(
-			LINE_THICKNESS,
-			LINE_THICKNESS,
-			(topPoint - bottomPoint).Magnitude + LINE_THICKNESS
-		)
-
-		leftCframe = CFrame.new(x, 0, 0) * CFrame.lookAt(topBottomMidpoint, topPoint)
-
-		rightSize = Vector3.new(
-			LINE_THICKNESS,
-			LINE_THICKNESS,
-			(topPoint - bottomPoint).Magnitude + LINE_THICKNESS
-		)
-
-		rightCframe = CFrame.new(-x, 0, 0) * CFrame.lookAt(topBottomMidpoint, topPoint)
-	end
-
 	return e("Folder", nil, {
 		left = e("BoxHandleAdornment", {
 			Adornee = part,
 			Color3 = props.color,
-			CFrame = leftCframe,
-			Size = leftSize,
+			CFrame = CFrame.new(-x, side * y, 0),
+			Size = sizeZ,
 			ZIndex = LINE_ZINDEX,
 		}),
 
 		right = e("BoxHandleAdornment", {
 			Adornee = part,
 			Color3 = props.color,
-			CFrame = rightCframe,
-			Size = rightSize,
+			CFrame = CFrame.new(x, side * y, 0),
+			Size = sizeZ,
 			ZIndex = LINE_ZINDEX,
 		}),
 
@@ -389,8 +380,8 @@ local function TopBottomWirebox(props: {
 		back = e("BoxHandleAdornment", {
 			Adornee = part,
 			Color3 = props.color,
-			CFrame = backCframe,
-			Size = backSize,
+			CFrame = CFrame.new(0, side * y, -z),
+			Size = sizeX,
 			ZIndex = LINE_ZINDEX,
 		}),
 	})

--- a/src/Frontend/Components/Gizmos/NormalGizmo.luau
+++ b/src/Frontend/Components/Gizmos/NormalGizmo.luau
@@ -14,7 +14,6 @@ local function LeftRightWirebox(props: {
 	end
 
 	local size = props.part.Size
-	local isWedge = props.part:IsA("WedgePart")
 
 	local x = size.X / 2
 	local y = size.Y / 2
@@ -27,18 +26,70 @@ local function LeftRightWirebox(props: {
 
 	local topSize = sizeZ
 	local topCframe = CFrame.new(side * x, y, 0)
+	local topVisible = true
 
-	if isWedge then
+	local leftSize = sizeY
+	local leftCframe = CFrame.new(side * x, 0, side * z)
+	local leftVisible = true
+
+	local rightSize = sizeY
+	local rightCframe = CFrame.new(side * x, 0, -side * z)
+	local rightVisible = true
+
+	if props.part:IsA("WedgePart") then
 		local hypotenuse = math.sqrt(size.Y ^ 2 + size.Z ^ 2)
 
 		topSize =
 			Vector3.new(LINE_THICKNESS, LINE_THICKNESS, hypotenuse + LINE_THICKNESS)
 		topCframe = CFrame.new(side * x, 0, 0)
 			* CFrame.Angles(-math.atan2(size.Y, size.Z), 0, 0)
+
+		leftVisible = side == 1
+		rightVisible = side == -1
+	elseif props.part:IsA("CornerWedgePart") then
+		topVisible = false
+
+		if side == -1 then
+			local bottomRightPoint = CFrame.new(-x, -y, z).Position
+			local bottomLeftPoint = CFrame.new(-x, -y, -z).Position
+			local topLeftPoint = CFrame.new(x, y, -z).Position
+
+			local topLeftBottomLeftMidpoint = (topLeftPoint + bottomLeftPoint) / 2
+			local topLeftBottomRightMidpoint = (topLeftPoint + bottomRightPoint) / 2
+
+			leftSize = Vector3.new(
+				LINE_THICKNESS,
+				LINE_THICKNESS,
+				(topLeftPoint - bottomLeftPoint).Magnitude + LINE_THICKNESS
+			)
+
+			leftCframe = CFrame.lookAt(topLeftBottomLeftMidpoint, topLeftPoint)
+
+			rightSize = Vector3.new(
+				LINE_THICKNESS,
+				LINE_THICKNESS,
+				(topLeftPoint - bottomRightPoint).Magnitude + LINE_THICKNESS
+			)
+
+			rightCframe = CFrame.lookAt(topLeftBottomRightMidpoint, topLeftPoint)
+		elseif side == 1 then
+			local topRightPoint = CFrame.new(x, y, -z).Position
+			local bottomLeftPoint = CFrame.new(x, -y, z).Position
+
+			local topRightBottomLeftMidpoint = (topRightPoint + bottomLeftPoint) / 2
+
+			leftSize = Vector3.new(
+				LINE_THICKNESS,
+				LINE_THICKNESS,
+				(topRightPoint - bottomLeftPoint).Magnitude + LINE_THICKNESS
+			)
+
+			leftCframe = CFrame.lookAt(topRightBottomLeftMidpoint, topRightPoint)
+		end
 	end
 
 	return e("Folder", nil, {
-		top = e("BoxHandleAdornment", {
+		top = topVisible and e("BoxHandleAdornment", {
 			Adornee = props.part,
 			Color3 = props.color,
 			CFrame = topCframe,
@@ -54,22 +105,21 @@ local function LeftRightWirebox(props: {
 			ZIndex = 2,
 		}),
 
-		left = (not isWedge or (isWedge and side == 1)) and e("BoxHandleAdornment", {
+		left = leftVisible and e("BoxHandleAdornment", {
 			Adornee = props.part,
 			Color3 = props.color,
-			CFrame = CFrame.new(side * x, 0, side * z),
-			Size = sizeY,
+			CFrame = leftCframe,
+			Size = leftSize,
 			ZIndex = 2,
 		}),
 
-		right = (not isWedge or (isWedge and side == -1))
-			and e("BoxHandleAdornment", {
-				Adornee = props.part,
-				Color3 = props.color,
-				CFrame = CFrame.new(side * x, 0, -side * z),
-				Size = sizeY,
-				ZIndex = 2,
-			}),
+		right = rightVisible and e("BoxHandleAdornment", {
+			Adornee = props.part,
+			Color3 = props.color,
+			CFrame = rightCframe,
+			Size = rightSize,
+			ZIndex = 2,
+		}),
 	})
 end
 
@@ -93,8 +143,58 @@ local function FrontBackWirebox(props: {
 
 	local side = props.normal == Enum.NormalId.Back and 1 or -1
 
+	local topVisible = true
+
+	local leftSize = sizeY
+	local leftCframe = CFrame.new(-side * x, 0, side * z)
+
+	local rightSize = sizeY
+	local rightCframe = CFrame.new(side * x, 0, side * z)
+
+	if props.part:IsA("CornerWedgePart") then
+		topVisible = false
+
+		if side == 1 then
+			local bottomRightPoint = CFrame.new(x, -y, z).Position
+			local bottomLeftPoint = CFrame.new(-x, -y, z).Position
+			local topLeftPoint = CFrame.new(x, y, -z).Position
+
+			local topLeftBottomLeftMidpoint = (topLeftPoint + bottomLeftPoint) / 2
+			local topLeftBottomRightMidpoint = (topLeftPoint + bottomRightPoint) / 2
+
+			leftSize = Vector3.new(
+				LINE_THICKNESS,
+				LINE_THICKNESS,
+				(topLeftPoint - bottomLeftPoint).Magnitude + LINE_THICKNESS
+			)
+
+			leftCframe = CFrame.lookAt(topLeftBottomLeftMidpoint, topLeftPoint)
+
+			rightSize = Vector3.new(
+				LINE_THICKNESS,
+				LINE_THICKNESS,
+				(topLeftPoint - bottomRightPoint).Magnitude + LINE_THICKNESS
+			)
+
+			rightCframe = CFrame.lookAt(topLeftBottomRightMidpoint, topLeftPoint)
+		elseif side == -1 then
+			local topLeftPoint = CFrame.new(x, y, -z).Position
+			local bottomRightPoint = CFrame.new(-x, -y, -z).Position
+
+			local topLeftBottomRightMidpoint = (topLeftPoint + bottomRightPoint) / 2
+
+			rightSize = Vector3.new(
+				LINE_THICKNESS,
+				LINE_THICKNESS,
+				(topLeftPoint - bottomRightPoint).Magnitude + LINE_THICKNESS
+			)
+
+			rightCframe = CFrame.lookAt(topLeftBottomRightMidpoint, topLeftPoint)
+		end
+	end
+
 	return e("Folder", nil, {
-		top = e("BoxHandleAdornment", {
+		top = topVisible and e("BoxHandleAdornment", {
 			Adornee = props.part,
 			Color3 = props.color,
 			CFrame = CFrame.new(0, y, side * z),
@@ -113,16 +213,16 @@ local function FrontBackWirebox(props: {
 		left = e("BoxHandleAdornment", {
 			Adornee = props.part,
 			Color3 = props.color,
-			CFrame = CFrame.new(side * x, 0, side * z),
-			Size = sizeY,
+			CFrame = leftCframe,
+			Size = leftSize,
 			ZIndex = 2,
 		}),
 
 		right = e("BoxHandleAdornment", {
 			Adornee = props.part,
 			Color3 = props.color,
-			CFrame = CFrame.new(-side * x, 0, side * z),
-			Size = sizeY,
+			CFrame = rightCframe,
+			Size = rightSize,
 			ZIndex = 2,
 		}),
 	})
@@ -137,8 +237,11 @@ local function TopBottomWirebox(props: {
 		return
 	end
 
+	if props.part:IsA("CornerWedgePart") and props.normal == Enum.NormalId.Top then
+		return
+	end
+
 	local size = props.part.Size
-	local isWedge = props.part:IsA("WedgePart")
 
 	local x = size.X / 2
 	local y = size.Y / 2
@@ -149,35 +252,44 @@ local function TopBottomWirebox(props: {
 
 	local side = props.normal == Enum.NormalId.Bottom and -1 or 1
 
-	local leftRightSize = sizeZ
-	local leftRightAngle = CFrame.identity
-	local leftRightHeight = side * y
+	local backSize = sizeX
 	local backCframe = CFrame.new(0, side * y, -z)
 
-	if isWedge and side == 1 then
-		local hypotenuse = math.sqrt(size.Y ^ 2 + size.Z ^ 2)
+	local leftSize = sizeZ
+	local leftCframe = CFrame.new(-x, side * y, 0)
 
-		leftRightSize =
-			Vector3.new(LINE_THICKNESS, LINE_THICKNESS, hypotenuse + LINE_THICKNESS)
-		leftRightAngle = CFrame.Angles(-math.atan2(size.Y, size.Z), 0, 0)
+	local rightSize = sizeZ
+	local rightCframe = CFrame.new(x, side * y, 0)
+
+	if props.part:IsA("WedgePart") and side == 1 then
+		local hypotenuse = math.sqrt(size.Y ^ 2 + size.Z ^ 2)
+		local angle = math.atan2(size.Y, size.Z)
+
 		backCframe = CFrame.new(0, -y, -z)
-		leftRightHeight = 0
+
+		leftSize =
+			Vector3.new(LINE_THICKNESS, LINE_THICKNESS, hypotenuse + LINE_THICKNESS)
+		leftCframe = CFrame.new(-x, 0, 0) * CFrame.Angles(-angle, 0, 0)
+
+		rightSize =
+			Vector3.new(LINE_THICKNESS, LINE_THICKNESS, hypotenuse + LINE_THICKNESS)
+		rightCframe = CFrame.new(x, 0, 0) * CFrame.Angles(-angle, 0, 0)
 	end
 
 	return e("Folder", nil, {
 		left = e("BoxHandleAdornment", {
 			Adornee = props.part,
 			Color3 = props.color,
-			CFrame = CFrame.new(-x, leftRightHeight, 0) * leftRightAngle,
-			Size = leftRightSize,
+			CFrame = leftCframe,
+			Size = leftSize,
 			ZIndex = 2,
 		}),
 
 		right = e("BoxHandleAdornment", {
 			Adornee = props.part,
 			Color3 = props.color,
-			CFrame = CFrame.new(x, leftRightHeight, 0) * leftRightAngle,
-			Size = leftRightSize,
+			CFrame = rightCframe,
+			Size = rightSize,
 			ZIndex = 2,
 		}),
 
@@ -193,7 +305,7 @@ local function TopBottomWirebox(props: {
 			Adornee = props.part,
 			Color3 = props.color,
 			CFrame = backCframe,
-			Size = sizeX,
+			Size = backSize,
 			ZIndex = 2,
 		}),
 	})

--- a/src/Frontend/Components/Gizmos/NormalGizmo.luau
+++ b/src/Frontend/Components/Gizmos/NormalGizmo.luau
@@ -14,8 +14,7 @@ local function LeftRightWirebox(props: {
 	end
 
 	local size = props.part.Size
-	local cframe = props.part.CFrame
-	local origin = CFrame.new(Vector3.zero, cframe.LookVector)
+	local isWedge = props.part:IsA("WedgePart")
 
 	local x = size.X / 2
 	local y = size.Y / 2
@@ -26,38 +25,51 @@ local function LeftRightWirebox(props: {
 
 	local side = props.normal == Enum.NormalId.Right and 1 or -1
 
+	local topSize = sizeZ
+	local topCframe = CFrame.new(side * x, y, 0)
+
+	if isWedge then
+		local hypotenuse = math.sqrt(size.Y ^ 2 + size.Z ^ 2)
+
+		topSize =
+			Vector3.new(LINE_THICKNESS, LINE_THICKNESS, hypotenuse + LINE_THICKNESS)
+		topCframe = CFrame.new(side * x, 0, 0)
+			* CFrame.Angles(-math.atan2(size.Y, size.Z), 0, 0)
+	end
+
 	return e("Folder", nil, {
 		top = e("BoxHandleAdornment", {
 			Adornee = props.part,
 			Color3 = props.color,
-			CFrame = origin * CFrame.new(side * x, y, 0),
-			Size = sizeZ,
+			CFrame = topCframe,
+			Size = topSize,
 			ZIndex = 2,
 		}),
 
 		bottom = e("BoxHandleAdornment", {
 			Adornee = props.part,
 			Color3 = props.color,
-			CFrame = origin * CFrame.new(side * x, -y, 0),
+			CFrame = CFrame.new(side * x, -y, 0),
 			Size = sizeZ,
 			ZIndex = 2,
 		}),
 
-		left = e("BoxHandleAdornment", {
+		left = (not isWedge or (isWedge and side == 1)) and e("BoxHandleAdornment", {
 			Adornee = props.part,
 			Color3 = props.color,
-			CFrame = origin * CFrame.new(side * x, 0, side * z),
+			CFrame = CFrame.new(side * x, 0, side * z),
 			Size = sizeY,
 			ZIndex = 2,
 		}),
 
-		right = e("BoxHandleAdornment", {
-			Adornee = props.part,
-			Color3 = props.color,
-			CFrame = origin * CFrame.new(side * x, 0, -side * z),
-			Size = sizeY,
-			ZIndex = 2,
-		}),
+		right = (not isWedge or (isWedge and side == -1))
+			and e("BoxHandleAdornment", {
+				Adornee = props.part,
+				Color3 = props.color,
+				CFrame = CFrame.new(side * x, 0, -side * z),
+				Size = sizeY,
+				ZIndex = 2,
+			}),
 	})
 end
 
@@ -71,8 +83,6 @@ local function FrontBackWirebox(props: {
 	end
 
 	local size = props.part.Size
-	local cframe = props.part.CFrame
-	local origin = CFrame.new(Vector3.zero, cframe.LookVector)
 
 	local x = size.X / 2
 	local y = size.Y / 2
@@ -87,7 +97,7 @@ local function FrontBackWirebox(props: {
 		top = e("BoxHandleAdornment", {
 			Adornee = props.part,
 			Color3 = props.color,
-			CFrame = origin * CFrame.new(0, y, side * z),
+			CFrame = CFrame.new(0, y, side * z),
 			Size = sizeX,
 			ZIndex = 2,
 		}),
@@ -95,7 +105,7 @@ local function FrontBackWirebox(props: {
 		bottom = e("BoxHandleAdornment", {
 			Adornee = props.part,
 			Color3 = props.color,
-			CFrame = origin * CFrame.new(0, -y, side * z),
+			CFrame = CFrame.new(0, -y, side * z),
 			Size = sizeX,
 			ZIndex = 2,
 		}),
@@ -103,7 +113,7 @@ local function FrontBackWirebox(props: {
 		left = e("BoxHandleAdornment", {
 			Adornee = props.part,
 			Color3 = props.color,
-			CFrame = origin * CFrame.new(side * x, 0, side * z),
+			CFrame = CFrame.new(side * x, 0, side * z),
 			Size = sizeY,
 			ZIndex = 2,
 		}),
@@ -111,7 +121,7 @@ local function FrontBackWirebox(props: {
 		right = e("BoxHandleAdornment", {
 			Adornee = props.part,
 			Color3 = props.color,
-			CFrame = origin * CFrame.new(-side * x, 0, side * z),
+			CFrame = CFrame.new(-side * x, 0, side * z),
 			Size = sizeY,
 			ZIndex = 2,
 		}),
@@ -128,8 +138,7 @@ local function TopBottomWirebox(props: {
 	end
 
 	local size = props.part.Size
-	local cframe = props.part.CFrame
-	local origin = CFrame.new(Vector3.zero, cframe.LookVector)
+	local isWedge = props.part:IsA("WedgePart")
 
 	local x = size.X / 2
 	local y = size.Y / 2
@@ -140,27 +149,42 @@ local function TopBottomWirebox(props: {
 
 	local side = props.normal == Enum.NormalId.Bottom and -1 or 1
 
+	local leftRightSize = sizeZ
+	local leftRightAngle = CFrame.identity
+	local leftRightHeight = side * y
+	local backCframe = CFrame.new(0, side * y, -z)
+
+	if isWedge and side == 1 then
+		local hypotenuse = math.sqrt(size.Y ^ 2 + size.Z ^ 2)
+
+		leftRightSize =
+			Vector3.new(LINE_THICKNESS, LINE_THICKNESS, hypotenuse + LINE_THICKNESS)
+		leftRightAngle = CFrame.Angles(-math.atan2(size.Y, size.Z), 0, 0)
+		backCframe = CFrame.new(0, -y, -z)
+		leftRightHeight = 0
+	end
+
 	return e("Folder", nil, {
 		left = e("BoxHandleAdornment", {
 			Adornee = props.part,
 			Color3 = props.color,
-			CFrame = origin * CFrame.new(-x, side * y, 0),
-			Size = sizeZ,
+			CFrame = CFrame.new(-x, leftRightHeight, 0) * leftRightAngle,
+			Size = leftRightSize,
 			ZIndex = 2,
 		}),
 
 		right = e("BoxHandleAdornment", {
 			Adornee = props.part,
 			Color3 = props.color,
-			CFrame = origin * CFrame.new(x, side * y, 0),
-			Size = sizeZ,
+			CFrame = CFrame.new(x, leftRightHeight, 0) * leftRightAngle,
+			Size = leftRightSize,
 			ZIndex = 2,
 		}),
 
 		front = e("BoxHandleAdornment", {
 			Adornee = props.part,
 			Color3 = props.color,
-			CFrame = origin * CFrame.new(0, side * y, z),
+			CFrame = CFrame.new(0, side * y, z),
 			Size = sizeX,
 			ZIndex = 2,
 		}),
@@ -168,7 +192,7 @@ local function TopBottomWirebox(props: {
 		back = e("BoxHandleAdornment", {
 			Adornee = props.part,
 			Color3 = props.color,
-			CFrame = origin * CFrame.new(0, side * y, -z),
+			CFrame = backCframe,
 			Size = sizeX,
 			ZIndex = 2,
 		}),

--- a/src/Frontend/Components/Gizmos/PartGizmo.luau
+++ b/src/Frontend/Components/Gizmos/PartGizmo.luau
@@ -7,11 +7,8 @@ local LINE_THICKNESS = 0.15
 local function BoxWireframe(props: {
 	part: BasePart,
 	color: Color3?,
-	origin: CFrame,
-	size: Vector3,
 })
-	local origin = props.origin
-	local size = props.size
+	local size = props.part.Size
 
 	local x = size.X / 2
 	local y = size.Y / 2
@@ -26,14 +23,14 @@ local function BoxWireframe(props: {
 			posX = e("BoxHandleAdornment", {
 				Adornee = props.part,
 				Color3 = props.color,
-				CFrame = origin * CFrame.new(0, y, z),
+				CFrame = CFrame.new(0, y, z),
 				Size = sizeX,
 				ZIndex = 2,
 			}),
 			negX = e("BoxHandleAdornment", {
 				Adornee = props.part,
 				Color3 = props.color,
-				CFrame = origin * CFrame.new(0, y, -z),
+				CFrame = CFrame.new(0, y, -z),
 				Size = sizeX,
 				ZIndex = 2,
 			}),
@@ -41,14 +38,14 @@ local function BoxWireframe(props: {
 			posZ = e("BoxHandleAdornment", {
 				Adornee = props.part,
 				Color3 = props.color,
-				CFrame = origin * CFrame.new(x, y, 0),
+				CFrame = CFrame.new(x, y, 0),
 				Size = sizeZ,
 				ZIndex = 2,
 			}),
 			negZ = e("BoxHandleAdornment", {
 				Adornee = props.part,
 				Color3 = props.color,
-				CFrame = origin * CFrame.new(-x, y, 0),
+				CFrame = CFrame.new(-x, y, 0),
 				Size = sizeZ,
 				ZIndex = 2,
 			}),
@@ -58,14 +55,14 @@ local function BoxWireframe(props: {
 			posX = e("BoxHandleAdornment", {
 				Adornee = props.part,
 				Color3 = props.color,
-				CFrame = origin * CFrame.new(0, -y, z),
+				CFrame = CFrame.new(0, -y, z),
 				Size = sizeX,
 				ZIndex = 2,
 			}),
 			negX = e("BoxHandleAdornment", {
 				Adornee = props.part,
 				Color3 = props.color,
-				CFrame = origin * CFrame.new(0, -y, -z),
+				CFrame = CFrame.new(0, -y, -z),
 				Size = sizeX,
 				ZIndex = 2,
 			}),
@@ -73,14 +70,14 @@ local function BoxWireframe(props: {
 			posZ = e("BoxHandleAdornment", {
 				Adornee = props.part,
 				Color3 = props.color,
-				CFrame = origin * CFrame.new(x, -y, 0),
+				CFrame = CFrame.new(x, -y, 0),
 				Size = sizeZ,
 				ZIndex = 2,
 			}),
 			negZ = e("BoxHandleAdornment", {
 				Adornee = props.part,
 				Color3 = props.color,
-				CFrame = origin * CFrame.new(-x, -y, 0),
+				CFrame = CFrame.new(-x, -y, 0),
 				Size = sizeZ,
 				ZIndex = 2,
 			}),
@@ -90,14 +87,14 @@ local function BoxWireframe(props: {
 			frontPosX = e("BoxHandleAdornment", {
 				Adornee = props.part,
 				Color3 = props.color,
-				CFrame = origin * CFrame.new(x, 0, z),
+				CFrame = CFrame.new(x, 0, z),
 				Size = sizeY,
 				ZIndex = 2,
 			}),
 			frontNegX = e("BoxHandleAdornment", {
 				Adornee = props.part,
 				Color3 = props.color,
-				CFrame = origin * CFrame.new(-x, 0, z),
+				CFrame = CFrame.new(-x, 0, z),
 				Size = sizeY,
 				ZIndex = 2,
 			}),
@@ -105,14 +102,14 @@ local function BoxWireframe(props: {
 			backPosX = e("BoxHandleAdornment", {
 				Adornee = props.part,
 				Color3 = props.color,
-				CFrame = origin * CFrame.new(x, 0, -z),
+				CFrame = CFrame.new(x, 0, -z),
 				Size = sizeY,
 				ZIndex = 2,
 			}),
 			backNegX = e("BoxHandleAdornment", {
 				Adornee = props.part,
 				Color3 = props.color,
-				CFrame = origin * CFrame.new(-x, 0, -z),
+				CFrame = CFrame.new(-x, 0, -z),
 				Size = sizeY,
 				ZIndex = 2,
 			}),
@@ -130,16 +127,6 @@ local function PartGizmo(props: {
 		return
 	end
 
-	local size = part.Size
-	local orientation = part.CFrame
-	local origin = CFrame.new(Vector3.zero, orientation.LookVector)
-
-	-- local isSphere = false
-
-	-- if part:IsA("Part") and part.Shape == Enum.PartType.Ball then
-	-- 	isSphere = true
-	-- end
-
 	return e("Folder", nil, {
 		outline = e("Highlight", {
 			Adornee = props.part,
@@ -150,8 +137,6 @@ local function PartGizmo(props: {
 		wireframe = e(BoxWireframe, {
 			part = part,
 			color = props.color,
-			origin = origin,
-			size = size,
 		}),
 	})
 end

--- a/src/Frontend/Themes/Dark.luau
+++ b/src/Frontend/Themes/Dark.luau
@@ -15,18 +15,6 @@ return {
 			pressed = Color3.new(),
 			disabled = Color3.fromHex("757575"),
 		},
-		accentVariant = {
-			default = Color3.fromHex("8f7807"),
-			hovered = Color3.fromHex("c2a823"),
-			pressed = Color3.fromHex("625204"),
-			disabled = Color3.fromHex("222222"),
-		},
-		onAccentVariant = {
-			default = Color3.new(),
-			hovered = Color3.fromHex("1a1a1a"),
-			pressed = Color3.new(1, 1, 1),
-			disabled = Color3.fromHex("757575"),
-		},
 		button = {
 			default = Color3.fromHex("3c3c3c"),
 			hovered = Color3.fromHex("4a4a4a"),

--- a/src/Frontend/Themes/Dark.luau
+++ b/src/Frontend/Themes/Dark.luau
@@ -15,6 +15,18 @@ return {
 			pressed = Color3.new(),
 			disabled = Color3.fromHex("757575"),
 		},
+		accentVariant = {
+			default = Color3.fromHex("8f7807"),
+			hovered = Color3.fromHex("c2a823"),
+			pressed = Color3.fromHex("625204"),
+			disabled = Color3.fromHex("222222"),
+		},
+		onAccentVariant = {
+			default = Color3.new(),
+			hovered = Color3.fromHex("1a1a1a"),
+			pressed = Color3.new(1, 1, 1),
+			disabled = Color3.fromHex("757575"),
+		},
 		button = {
 			default = Color3.fromHex("3c3c3c"),
 			hovered = Color3.fromHex("4a4a4a"),

--- a/src/Frontend/Widgets/ContextualToolbar.luau
+++ b/src/Frontend/Widgets/ContextualToolbar.luau
@@ -18,10 +18,17 @@ local useTheme = require("../Hooks/useTheme")
 local createNextOrder = require("../Lib/createNextOrder")
 local e = React.createElement
 
+local NO_MATERIAL_VARIANTS = {
+	[Enum.SurfaceType.Motor] = true,
+	[Enum.SurfaceType.SteppingMotor] = true,
+	[Enum.SurfaceType.Hinge] = true,
+}
+
 local function ContextualToolbar()
 	local nextOrder = createNextOrder()
 	local theme = useTheme()
 
+	local selectedSurface = useValue(Preferences.selectedSurface)
 	local applyToAllFaces = useValue(Preferences.applyToAllfaces)
 	local applyToAllFacesOverride = useValue(LocalStore.applyToAllfacesOverride)
 	local useMaterialVariants = useValue(Preferences.useMaterialVariants)
@@ -74,7 +81,7 @@ local function ContextualToolbar()
 		}),
 
 		useMaterialVariants = e(ContextualActionContainer, {
-			visible = isApplyToAllFaces,
+			visible = isApplyToAllFaces and not NO_MATERIAL_VARIANTS[selectedSurface],
 			layoutOrder = nextOrder(),
 		}, {
 			tooltip = e(Tooltip, {

--- a/src/Frontend/Widgets/SelectionTracker.luau
+++ b/src/Frontend/Widgets/SelectionTracker.luau
@@ -1,3 +1,5 @@
+local plugin: Plugin = plugin or script:FindFirstAncestorOfClass("Plugin")
+
 local Selection = game:GetService("Selection")
 local UserInputService = game:GetService("UserInputService")
 
@@ -19,21 +21,6 @@ local useEffect = React.useEffect
 local useState = React.useState
 
 local e = React.createElement
-
-local RAYCAST_PARAMS = RaycastParams.new()
-RAYCAST_PARAMS.BruteForceAllSlow = false
-RAYCAST_PARAMS.CollisionGroup = "StudioSelectable"
-RAYCAST_PARAMS.IgnoreWater = true
-RAYCAST_PARAMS.RespectCanCollide = true
-
-local NORMAL_MAP = {
-	[Vector3.yAxis] = Enum.NormalId.Top,
-	[-Vector3.yAxis] = Enum.NormalId.Bottom,
-	[Vector3.xAxis] = Enum.NormalId.Right,
-	[-Vector3.xAxis] = Enum.NormalId.Left,
-	[-Vector3.zAxis] = Enum.NormalId.Front,
-	[Vector3.zAxis] = Enum.NormalId.Back,
-}
 
 local function containsActionableSelection(selection: { Instance }?, iterated: boolean?)
 	if selection then
@@ -91,6 +78,35 @@ local function SelectionTracker()
 
 		local hasActionableSelection = containsActionableSelection(Selection:Get())
 		LocalStore.hasActionableSelection(hasActionableSelection)
+
+		local mouse = plugin:GetMouse()
+		local connection = mouse.Move:Connect(function()
+			local normal = mouse.TargetSurface
+			local target = mouse.Target
+
+			local isValidTarget = target
+				and target:IsA("BasePart")
+				and not target.Locked
+
+			if not isValidTarget then
+				setTargetPart(nil)
+				setTargetNormal(nil)
+				return
+			end
+
+			if target:IsA("WedgePart") then
+				if normal == Enum.NormalId.Front then
+					normal = Enum.NormalId.Top
+				end
+			end
+
+			setTargetPart(target)
+			setTargetNormal(normal)
+		end)
+
+		return function()
+			connection:Disconnect()
+		end
 	end, { isPluginActive })
 
 	useEvent(Selection.SelectionChanged, function()
@@ -107,51 +123,6 @@ local function SelectionTracker()
 		then
 			onClickCallback()
 		end
-	end, {
-		connected = isPluginActive,
-	})
-
-	useEvent(UserInputService.InputChanged, function(inputObject, gameProcessed)
-		if
-			gameProcessed
-			or inputObject.UserInputType ~= Enum.UserInputType.MouseMovement
-		then
-			return
-		end
-
-		local camera = workspace.CurrentCamera
-		local mouseRay =
-			camera:ViewportPointToRay(inputObject.Position.X, inputObject.Position.Y)
-
-		local result = workspace:Raycast(
-			mouseRay.Origin,
-			mouseRay.Direction * 2048,
-			RAYCAST_PARAMS
-		)
-
-		local isValidTarget = result
-			and result.Instance:IsA("BasePart")
-			and not result.Instance.Locked
-
-		if not isValidTarget then
-			setTargetPart(nil)
-			setTargetNormal(nil)
-
-			return
-		end
-
-		local roundedNormal = result.Normal
-
-		if roundedNormal then
-			roundedNormal = Vector3.new(
-				math.floor(roundedNormal.X + 0.5),
-				math.floor(roundedNormal.Y + 0.5),
-				math.floor(roundedNormal.Z + 0.5)
-			)
-		end
-
-		setTargetPart(result.Instance)
-		setTargetNormal(NORMAL_MAP[roundedNormal])
 	end, {
 		connected = isPluginActive,
 	})

--- a/src/Frontend/Widgets/SelectionTracker.luau
+++ b/src/Frontend/Widgets/SelectionTracker.luau
@@ -1,5 +1,3 @@
-local plugin: Plugin = plugin or script:FindFirstAncestorOfClass("Plugin")
-
 local Selection = game:GetService("Selection")
 local UserInputService = game:GetService("UserInputService")
 
@@ -21,6 +19,15 @@ local useEffect = React.useEffect
 local useState = React.useState
 
 local e = React.createElement
+
+local NORMAL_MAP = {
+	[Vector3.yAxis] = Enum.NormalId.Top,
+	[-Vector3.yAxis] = Enum.NormalId.Bottom,
+	[Vector3.xAxis] = Enum.NormalId.Right,
+	[-Vector3.xAxis] = Enum.NormalId.Left,
+	[-Vector3.zAxis] = Enum.NormalId.Front,
+	[Vector3.zAxis] = Enum.NormalId.Back,
+}
 
 local RAYCAST_PARAMS = RaycastParams.new()
 RAYCAST_PARAMS.BruteForceAllSlow = false
@@ -84,38 +91,6 @@ local function SelectionTracker()
 
 		local hasActionableSelection = containsActionableSelection(Selection:Get())
 		LocalStore.hasActionableSelection(hasActionableSelection)
-
-		local mouse = plugin:GetMouse()
-		local connection = mouse.Move:Connect(function()
-			local normal = mouse.TargetSurface
-			local target = mouse.Target
-
-			local isValidTarget = target
-				and target:IsA("BasePart")
-				and not target.Locked
-
-			if not isValidTarget then
-				setTargetPart(nil)
-				setTargetNormal(nil)
-				return
-			end
-
-			if
-				target:IsA("WedgePart")
-				or (target:IsA("Part") and target.Shape == Enum.PartType.Wedge)
-			then
-				if normal == Enum.NormalId.Top then
-					normal = Enum.NormalId.Front
-				end
-			end
-
-			setTargetPart(target)
-			setTargetNormal(normal)
-		end)
-
-		return function()
-			connection:Disconnect()
-		end
 	end, { isPluginActive })
 
 	useEvent(Selection.SelectionChanged, function()
@@ -136,42 +111,77 @@ local function SelectionTracker()
 		connected = isPluginActive,
 	})
 
-	-- useEvent(UserInputService.InputChanged, function(inputObject, gameProcessed)
-	-- 	if
-	-- 		gameProcessed
-	-- 		or inputObject.UserInputType ~= Enum.UserInputType.MouseMovement
-	-- 	then
-	-- 		return
-	-- 	end
+	useEvent(UserInputService.InputChanged, function(inputObject, gameProcessed)
+		if
+			gameProcessed
+			or inputObject.UserInputType ~= Enum.UserInputType.MouseMovement
+		then
+			return
+		end
 
-	-- 	local camera = workspace.CurrentCamera
-	-- 	local mouseRay =
-	-- 		camera:ViewportPointToRay(inputObject.Position.X, inputObject.Position.Y)
+		local camera = workspace.CurrentCamera
+		local mouseRay =
+			camera:ViewportPointToRay(inputObject.Position.X, inputObject.Position.Y)
 
-	-- 	local result = workspace:Raycast(
-	-- 		mouseRay.Origin,
-	-- 		mouseRay.Direction * 2048,
-	-- 		RAYCAST_PARAMS
-	-- 	)
+		local result = workspace:Raycast(
+			mouseRay.Origin,
+			mouseRay.Direction * 2048,
+			RAYCAST_PARAMS
+		)
 
-	-- 	local isValidTarget = result
-	-- 		and result.Instance:IsA("BasePart")
-	-- 		and not result.Instance.Locked
+		local isValidTarget = result
+			and result.Instance:IsA("BasePart")
+			and not result.Instance.Locked
 
-	-- 	if not isValidTarget then
-	-- 		-- setTargetPart(nil)
-	-- 		-- setTargetNormal(nil)
+		if not isValidTarget then
+			setTargetPart(nil)
+			setTargetNormal(nil)
 
-	-- 		return
-	-- 	end
+			return
+		end
 
-	-- 	-- print("normal>", result.Normal)
+		local target: BasePart = result.Instance
+		local normal = target.CFrame:VectorToObjectSpace(result.Normal)
 
-	-- 	-- setTargetPart(result.Instance)
-	-- 	-- setTargetNormal(NORMAL_MAP[roundedNormal])
-	-- end, {
-	-- 	connected = isPluginActive,
-	-- })
+		if normal then
+			local top = math.floor(normal:Dot(Vector3.yAxis) + 0.5)
+			local right = math.floor(normal:Dot(Vector3.xAxis) + 0.5)
+			local front = math.floor(normal:Dot(Vector3.zAxis) + 0.5)
+
+			if top == 1 then
+				normal = Vector3.yAxis
+			elseif top == -1 then
+				normal = -Vector3.yAxis
+			end
+
+			if right == 1 then
+				normal = Vector3.xAxis
+			elseif right == -1 then
+				normal = -Vector3.xAxis
+			end
+
+			if front == 1 then
+				normal = Vector3.zAxis
+			elseif front == -1 then
+				normal = -Vector3.zAxis
+			end
+		end
+
+		local isWedge = target:IsA("WedgePart")
+
+		if target:IsA("Part") and target.Shape == Enum.PartType.Wedge then
+			isWedge = true
+		end
+
+		if isWedge and normal == Vector3.yAxis then
+			normal = -Vector3.zAxis
+		end
+
+		setTargetPart(target)
+		setTargetNormal(NORMAL_MAP[normal])
+	end, {
+		connected = isPluginActive,
+	})
 
 	if not isPluginActive or not targetPart then
 		return

--- a/src/Frontend/Widgets/SelectionTracker.luau
+++ b/src/Frontend/Widgets/SelectionTracker.luau
@@ -22,6 +22,12 @@ local useState = React.useState
 
 local e = React.createElement
 
+local RAYCAST_PARAMS = RaycastParams.new()
+RAYCAST_PARAMS.BruteForceAllSlow = false
+RAYCAST_PARAMS.CollisionGroup = "StudioSelectable"
+RAYCAST_PARAMS.IgnoreWater = true
+RAYCAST_PARAMS.RespectCanCollide = true
+
 local function containsActionableSelection(selection: { Instance }?, iterated: boolean?)
 	if selection then
 		for _, object in selection do
@@ -94,7 +100,10 @@ local function SelectionTracker()
 				return
 			end
 
-			if target:IsA("WedgePart") then
+			if
+				target:IsA("WedgePart")
+				or (target:IsA("Part") and target.Shape == Enum.PartType.Wedge)
+			then
 				if normal == Enum.NormalId.Front then
 					normal = Enum.NormalId.Top
 				end
@@ -126,6 +135,43 @@ local function SelectionTracker()
 	end, {
 		connected = isPluginActive,
 	})
+
+	-- useEvent(UserInputService.InputChanged, function(inputObject, gameProcessed)
+	-- 	if
+	-- 		gameProcessed
+	-- 		or inputObject.UserInputType ~= Enum.UserInputType.MouseMovement
+	-- 	then
+	-- 		return
+	-- 	end
+
+	-- 	local camera = workspace.CurrentCamera
+	-- 	local mouseRay =
+	-- 		camera:ViewportPointToRay(inputObject.Position.X, inputObject.Position.Y)
+
+	-- 	local result = workspace:Raycast(
+	-- 		mouseRay.Origin,
+	-- 		mouseRay.Direction * 2048,
+	-- 		RAYCAST_PARAMS
+	-- 	)
+
+	-- 	local isValidTarget = result
+	-- 		and result.Instance:IsA("BasePart")
+	-- 		and not result.Instance.Locked
+
+	-- 	if not isValidTarget then
+	-- 		-- setTargetPart(nil)
+	-- 		-- setTargetNormal(nil)
+
+	-- 		return
+	-- 	end
+
+	-- 	-- print("normal>", result.Normal)
+
+	-- 	-- setTargetPart(result.Instance)
+	-- 	-- setTargetNormal(NORMAL_MAP[roundedNormal])
+	-- end, {
+	-- 	connected = isPluginActive,
+	-- })
 
 	if not isPluginActive or not targetPart then
 		return

--- a/src/Frontend/Widgets/SelectionTracker.luau
+++ b/src/Frontend/Widgets/SelectionTracker.luau
@@ -143,10 +143,52 @@ local function SelectionTracker()
 		local target: BasePart = result.Instance
 		local normal = target.CFrame:VectorToObjectSpace(result.Normal)
 
+		local isWedge = target:IsA("WedgePart")
+		local isCornerWedge = target:IsA("CornerWedgePart")
+
+		if target:IsA("Part") then
+			isWedge = target.Shape == Enum.PartType.Wedge
+			isCornerWedge = target.Shape == Enum.PartType.CornerWedge
+		end
+
 		if normal then
-			local top = math.floor(normal:Dot(Vector3.yAxis) + 0.5)
-			local right = math.floor(normal:Dot(Vector3.xAxis) + 0.5)
-			local front = math.floor(normal:Dot(Vector3.zAxis) + 0.5)
+			local top = math.floor(normal:Abs():Dot(Vector3.yAxis) + 0.5)
+			local topSign = math.sign(normal.Y)
+
+			local right = math.floor(normal:Abs():Dot(Vector3.xAxis) + 0.5)
+			local rightSign = math.sign(normal.X)
+
+			local front = math.floor(normal:Abs():Dot(Vector3.zAxis) + 0.5)
+			local frontSign = math.sign(normal.Z)
+
+			print({
+				top = top,
+				right = right,
+				front = front,
+			})
+
+			if isCornerWedge then
+				if (top ~= 0 and right ~= 0) or top == 1 then
+					right, top = top, right
+				end
+			end
+
+			if front >= top and front >= right then
+				top, right = 0, 0
+				front *= frontSign
+			elseif right >= top and right >= front then
+				top, front = 0, 0
+				right *= rightSign
+			elseif top >= right and top >= front then
+				right, front = 0, 0
+				top *= topSign
+			end
+
+			if front == 1 then
+				normal = Vector3.zAxis
+			elseif front == -1 then
+				normal = -Vector3.zAxis
+			end
 
 			if top == 1 then
 				normal = Vector3.yAxis
@@ -159,18 +201,6 @@ local function SelectionTracker()
 			elseif right == -1 then
 				normal = -Vector3.xAxis
 			end
-
-			if front == 1 then
-				normal = Vector3.zAxis
-			elseif front == -1 then
-				normal = -Vector3.zAxis
-			end
-		end
-
-		local isWedge = target:IsA("WedgePart")
-
-		if target:IsA("Part") and target.Shape == Enum.PartType.Wedge then
-			isWedge = true
 		end
 
 		if isWedge and normal == Vector3.yAxis then

--- a/src/Frontend/Widgets/SelectionTracker.luau
+++ b/src/Frontend/Widgets/SelectionTracker.luau
@@ -104,8 +104,8 @@ local function SelectionTracker()
 				target:IsA("WedgePart")
 				or (target:IsA("Part") and target.Shape == Enum.PartType.Wedge)
 			then
-				if normal == Enum.NormalId.Front then
-					normal = Enum.NormalId.Top
+				if normal == Enum.NormalId.Top then
+					normal = Enum.NormalId.Front
 				end
 			end
 

--- a/src/Frontend/Widgets/SurfacePickerWidget.luau
+++ b/src/Frontend/Widgets/SurfacePickerWidget.luau
@@ -151,8 +151,13 @@ local function SurfacePickerWidget(props: {
 						selectIndex = foundIndex
 					end
 
-					Preferences.selectedSurface(surfaceTypes[selectIndex])
-					LocalStore.currentWidget(nil)
+					if surfaceTypes[selectIndex] or quickSelectSurfaceType then
+						Preferences.selectedSurface(
+							surfaceTypes[selectIndex] or quickSelectSurfaceType
+						)
+
+						LocalStore.currentWidget(nil)
+					end
 				end,
 			}),
 

--- a/src/Stores/Preferences.luau
+++ b/src/Stores/Preferences.luau
@@ -175,4 +175,10 @@ do -- Persistence
 	end)
 end
 
+do
+	if store.selectedSurface() == nil then
+		store.selectedSurface.reset()
+	end
+end
+
 return store

--- a/src/init.client.luau
+++ b/src/init.client.luau
@@ -5,13 +5,10 @@ local React = require("@pkgs/React")
 local ReactRoblox = require("@pkgs/ReactRoblox")
 
 local LocalStore = require("./Stores/LocalStore")
-local Preferences = require("./Stores/Preferences")
 
 -- Migrations to ease transition from Surface Tool
 if plugin:GetSetting("currentVersion") ~= nil then
 	LocalStore.isLegacyPluginTransition(true)
-	Preferences.setMaterialToPlastic(false)
-	Preferences.useMaterialVariants(false)
 end
 
 local App = require("./Frontend/App")

--- a/wally.toml
+++ b/wally.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cxmeel/resurface"
-version = "0.1.0"
+version = "0.1.1"
 registry = "https://github.com/UpliftGames/wally-index"
 realm = "shared"
 


### PR DESCRIPTION
- Hovering over a WedgePart, CornerWedgePart or rotated part's face will now highlight the correct face
- Improved selection gizmos for Wedges, CornerWedgeParts, Cylinders, Balls and parts that use the Wedge and CornerWedge shapes
- Fixed a bug where the surface picker widget would allow the selected surface to be `nil` if no matches were found when searching
- Disabled MaterialVariant contextual action for Motor, SteppingMotor and Hinge, as there is no MaterialVariant texture for these